### PR TITLE
update GHA wfs to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   style-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Go
@@ -30,7 +30,7 @@ jobs:
         version: v1.54.2
         args: --timeout=3m
   go-unit-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [style-check]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci-release-dev.yaml
+++ b/.github/workflows/ci-release-dev.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   set-version: # Get version as first job to re-use the value without needing to re-calculate it.
     name: Set Version for Dev Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
       version: ${{ steps.set_version.outputs.version }}
@@ -26,7 +26,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Set version to $VERSION"
   docker-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [set-version]
     steps:
       - name: Checkout
@@ -47,7 +47,7 @@ jobs:
   release-helm:
     name: Release gloo-portal-idp-connect helm chart
     needs: [set-version]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.4.0

--- a/.github/workflows/ci-release-dev.yaml
+++ b/.github/workflows/ci-release-dev.yaml
@@ -31,13 +31,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Gcloud Login
-        uses: google-github-actions/setup-gcloud@a48b55b3b0eeaf77b6e1384aab737fbefe2085ac
+
+      - name: Gcloud Auth
+        uses: google-github-actions/auth@v2
         with:
-          version: '386.0.0'
+          credentials_json: ${{ secrets.ARTIFACT_PUSHER_JSON_KEY }}
           project_id: gloo-mesh
-          service_account_key: ${{ secrets.ARTIFACT_PUSHER_JSON_KEY }}
-          export_default_credentials: true
+          create_credentials_file: true
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: 416.0.0
+
       - name: Publish Docker image
         env:
           TAGGED_VERSION: ${{ needs.set-version.outputs.version }}

--- a/.github/workflows/ci-release-dev.yaml
+++ b/.github/workflows/ci-release-dev.yaml
@@ -55,13 +55,19 @@ jobs:
           access_token: ${{ github.token }}
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Gcloud Login
-        uses: google-github-actions/setup-gcloud@a48b55b3b0eeaf77b6e1384aab737fbefe2085ac
+
+      - name: Gcloud Auth
+        uses: google-github-actions/auth@v2
         with:
-          version: '386.0.0'
+          credentials_json: ${{ secrets.GLOO_RELEASE_ADMIN }}
           project_id: gloo-mesh
-          service_account_key: ${{ secrets.GLOO_RELEASE_ADMIN }}
-          export_default_credentials: true
+          create_credentials_file: true
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: 416.0.0
+
       - name: Publish Helm
         env:
           TAGGED_VERSION: ${{ needs.set-version.outputs.version }}

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   style-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: golangci-lint
@@ -17,7 +17,7 @@ jobs:
           version: v1.54.2
           args: --timeout=3m
   docker-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -36,7 +36,7 @@ jobs:
           make docker-release
   release-helm:
     name: Release gloo-portal-idp-connect helm chart
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.4.0

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -44,13 +44,19 @@ jobs:
           access_token: ${{ github.token }}
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Gcloud Login
-        uses: google-github-actions/setup-gcloud@a48b55b3b0eeaf77b6e1384aab737fbefe2085ac
+
+      - name: Gcloud Auth
+        uses: google-github-actions/auth@v2
         with:
-          version: '386.0.0'
+          credentials_json: ${{ secrets.GLOO_RELEASE_ADMIN }}
           project_id: gloo-mesh
-          service_account_key: ${{ secrets.GLOO_RELEASE_ADMIN }}
-          export_default_credentials: true
+          create_credentials_file: true
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: 416.0.0
+
       - name: Publish Helm
         env:
           TAGGED_VERSION: ${{ github.event.release.tag_name }}

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -21,13 +21,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Gcloud Login
-        uses: google-github-actions/setup-gcloud@a48b55b3b0eeaf77b6e1384aab737fbefe2085ac
+
+      - name: Gcloud Auth
+        uses: google-github-actions/auth@v2
         with:
-          version: '386.0.0'
+          credentials_json: ${{ secrets.ARTIFACT_PUSHER_JSON_KEY }}
           project_id: gloo-mesh
-          service_account_key: ${{ secrets.ARTIFACT_PUSHER_JSON_KEY }}
-          export_default_credentials: true
+          create_credentials_file: true
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: 416.0.0
+
       - name: Publish Docker image
         env:
           TAGGED_VERSION: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Updating GH workflows to ubuntu-24.04 as ubuntu-20.04 will be EOL soon.

also updated release wfs to use ubuntu-24.04 instead of ubuntu-latest for building container images, this is to avoid any issues for release if it breaks on ubuntu-latest

related issue: https://github.com/solo-io/solo-projects/issues/7926

### Testing
[Dev release](https://github.com/solo-io/gloo-portal-idp-connect/actions/runs/14500019693), fixed failing gcloud setup on ubuntu-24.04
[Dev release](https://github.com/solo-io/gloo-portal-idp-connect/actions/runs/14498491583), failed for gcloud setup 